### PR TITLE
(chore) Updated log4j version to 2.17.1 [KETI-2157]

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,7 +6,7 @@ ext {
 // Versions we're overriding from the Spring Boot Bom
 ext["mariadb.version"] = "2.3.0"
 ext["flyway.version"] = "5.2.4"
-ext['log4j2.version'] = '2.17.0' // this pinning can be removed when we bump to a spring boot version that has 2.15.0+ (due to CVE https://github.com/advisories/GHSA-jfh8-c2jp-5v3q in log4j < 2.15.0)
+ext['log4j2.version'] = '2.17.1' // this pinning can be removed when we bump to a spring boot version that has 2.15.0+ (due to CVE https://github.com/advisories/GHSA-jfh8-c2jp-5v3q in log4j < 2.15.0)
 
 // Versions shared between multiple dependencies
 versions.aspectJVersion = "1.9.4"


### PR DESCRIPTION
Signed-off-by: Bharath Sekar <bsekar@guidewire.com>