### PR TITLE
chore: Update Tomcat, bouncycastle version and fix unit test failure [KETI-5401]

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -12,13 +12,13 @@ ext['log4j2.version'] = '2.17.1' // this pinning can be removed when we bump to 
 // Versions shared between multiple dependencies
 versions.aspectJVersion = "1.9.4"
 versions.apacheDsVersion = "2.0.0.AM26"
-versions.bouncyCastleVersion = "1.72"
+versions.bouncyCastleVersion = "1.78"
 versions.hamcrestVersion = "2.2"
 versions.springBootVersion = "2.7.6"
 versions.springSecurityJwtVersion = "1.1.1.RELEASE"
 versions.springSecurityOAuthVersion = "2.5.2.RELEASE"
 versions.springSecuritySamlVersion = "1.0.10.RELEASE"
-versions.tomcatCargoVersion = "9.0.70"
+versions.tomcatCargoVersion = "9.0.93"
 versions.guavaVersion = "31.1-jre"
 
 ext {

--- a/server/src/test/java/org/cloudfoundry/identity/uaa/util/KeyWithCertTest.java
+++ b/server/src/test/java/org/cloudfoundry/identity/uaa/util/KeyWithCertTest.java
@@ -108,7 +108,7 @@ public class KeyWithCertTest {
         "PwMhO0+dASJ83e2Bu63pKO808BrVjD51sSEMb0qwFc5IV6RzK/mkJgO0fphhoqOm\n" +
         "ZLzGcSYwCmj0Vc0GO5NgnFVZg4N9CyYCpDMeQynumlrNhRgnZRzlqXtQgL2bQDiu\n" +
         "coxNL/KY05iVlE1bmq/fzNEmEi2zf3dQV8CNSYs=\n" +
-        "-----END CERTIFICATE----\n";
+        "-----END CERTIFICATE-----\n";
 
     // openssl req -out cert.pem -nodes -keyout private.key -newkey rsa:2048 -new -x509
     public static final String opensslCert = "-----BEGIN CERTIFICATE-----\n" +


### PR DESCRIPTION
- Update bouncyCastle version from 1.72 to 1.78
- Update Tomcat version from 9.0.70 to 9.0.93
- Fixed unit test failure for bouncyCastle upgrade